### PR TITLE
netd: Don't fail on FTP or PPTP conntrack failure

### DIFF
--- a/server/Android.bp
+++ b/server/Android.bp
@@ -117,6 +117,9 @@ cc_library_static {
             target_needs_netd_direct_connect_rule: {
                 cppflags: ["-DNEEDS_NETD_DIRECT_CONNECT_RULE"],
             },
+            target_ignores_ftp_pptp_conntrack_failure: {
+                cppflags: ["-DIGNORES_FTP_PPTP_CONNTRACK_FAILURE"],
+            },
         },
     },
 }

--- a/server/TetherController.cpp
+++ b/server/TetherController.cpp
@@ -701,12 +701,14 @@ int TetherController::setForwardRules(bool add, const char *intIface, const char
     }
 
     std::vector<std::string> v4 = {
+#ifndef IGNORES_FTP_PPTP_CONNTRACK_FAILURE
             "*raw",
             StringPrintf("%s %s -p tcp --dport 21 -i %s -j CT --helper ftp", op,
                          LOCAL_RAW_PREROUTING, intIface),
             StringPrintf("%s %s -p tcp --dport 1723 -i %s -j CT --helper pptp", op,
                          LOCAL_RAW_PREROUTING, intIface),
             "COMMIT",
+#endif
             "*filter",
             StringPrintf("%s %s -i %s -o %s -m state --state ESTABLISHED,RELATED -g %s", op,
                          LOCAL_FORWARD, extIface, intIface, LOCAL_TETHER_COUNTERS_CHAIN),


### PR DESCRIPTION
The issue has been seen on some Samsung devices.
See https://github.com/phhusson/treble_experimentations/issues/425

Thanks @zamrih for pin-pointing the issue and validating fix

Change-Id: I3d9c865eb5a4b421f9983210c2ceae62b4906234
Signed-off-by: theimpulson <aayushgupta219@gmail.com>